### PR TITLE
CI追加とgolangci-lint指摘の修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+
+      - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          version: latest

--- a/main.go
+++ b/main.go
@@ -59,8 +59,6 @@ func main() {
 
 	var err error
 
-	rand.Seed(time.Now().UnixNano())
-
 	dsn := os.Getenv("DSN")
 	if dsn == "" {
 		log.Fatal("DSN environment variable required. [username[:password]@][protocol[(address)]]/dbname[?param1=value1&...&paramN=valueN]")
@@ -79,7 +77,11 @@ func main() {
 		initTable(initRecords)
 	}
 
-	defer db.Close()
+	defer func() {
+		if err := db.Close(); err != nil {
+			log.Println(err)
+		}
+	}()
 
 	err = db.Ping()
 	if err != nil {
@@ -95,7 +97,9 @@ func main() {
 
 	seqs := []Sequence{}
 
-	err = db.Select(&seqs, "SELECT id, counter FROM sequences ORDER BY id")
+	if err = db.Select(&seqs, "SELECT id, counter FROM sequences ORDER BY id"); err != nil {
+		log.Fatal(err)
+	}
 
 	wgWorker := sync.WaitGroup{}
 	for i := 0; i < workers; i++ {
@@ -114,7 +118,9 @@ func main() {
 
 	if verbose {
 		seqs = []Sequence{}
-		err = db.Select(&seqs, "SELECT id, counter FROM sequences ORDER BY id")
+		if err = db.Select(&seqs, "SELECT id, counter FROM sequences ORDER BY id"); err != nil {
+			log.Fatal(err)
+		}
 		for _, s := range seqs {
 			fmt.Printf("AFTER %s = %d\n", s.Id, s.Counter)
 		}
@@ -129,7 +135,7 @@ func IncrWorker(wg *sync.WaitGroup, ch <-chan string, respCh chan int64) {
 	defer wg.Done()
 	for {
 		id, more :=  <-ch
-		if more == false {
+		if !more {
 			break
 		}
 
@@ -148,7 +154,7 @@ func IncrWorker(wg *sync.WaitGroup, ch <-chan string, respCh chan int64) {
 		}
 		if err != nil {
 			log.Println(err)
-			tx.Rollback()
+			_ = tx.Rollback()
 			continue
 		}
 		if dbServer == "mysql" {
@@ -158,13 +164,13 @@ func IncrWorker(wg *sync.WaitGroup, ch <-chan string, respCh chan int64) {
 		}
 		if err != nil {
 			log.Println(err)
-			tx.Rollback()
+			_ = tx.Rollback()
 			continue
 		}
 		err = tx.Commit()
 		if err != nil {
 			log.Println(err)
-			tx.Rollback()
+			_ = tx.Rollback()
 			continue
 		}
 
@@ -183,7 +189,7 @@ func responseChecker(wg *sync.WaitGroup, ch <- chan int64) {
 	data := make([]float64, 0, 1000)
 	for {
 		msec, more := <-ch
-		if more == false {
+		if !more {
 			break
 		}
 		data = append(data, float64(msec))


### PR DESCRIPTION
## 概要

- PR時に `go build` と `golangci-lint` を実行するGitHub Actionsワークフロー（`.github/workflows/build.yml`）を追加
- `golangci-lint` で指摘された問題を修正

## 変更内容

### `.github/workflows/build.yml`
- `build` ジョブ: `go build ./...` を実行
- `lint` ジョブ: `golangci-lint-action` を使って lint を実行
- すべての action はコミットハッシュで固定（`pinact` 使用）

### `main.go`（golangci-lint 修正）
- `rand.Seed` 削除（Go 1.20以降 deprecated）
- `defer db.Close()` のエラーをログ出力するよう修正（errcheck）
- `db.Select()` の戻り値エラーをチェックするよう修正（ineffassign）
- `tx.Rollback()` を `_ = tx.Rollback()` に変更（errcheck）
- `more == false` を `!more` に簡略化（staticcheck）

## テスト計画
- [ ] PRを作成してGitHub Actionsの `build` ジョブが成功することを確認
- [ ] PRを作成してGitHub Actionsの `lint` ジョブが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)